### PR TITLE
fix: add tilde (~) to keepPrefix list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const proccessVersion = (newVersion, currentVersion) => {
     if (program.keepVariable && program.keepVariable.split(',').find(f => currentVersion.includes(f)))
         return currentVersion;
     if (program.keepPrefix) {
-      const match = currentVersion.match(/(^[\^><=]+)/);
+      const match = currentVersion.match(/(^[\^><=~]+)/);
       const range = match ? match[0] : '';
       return range + newVersion;
     }
@@ -52,7 +52,7 @@ const yarnLockSyncIntoPackageJson = (packageJsonObject, yarnLockObject) => {
         }
     });
     return packageJsonObject;
-};
+};~
 
 function getLineFeed(source: string) {
     const match = source.match(/\r?\n/);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const yarnLockSyncIntoPackageJson = (packageJsonObject, yarnLockObject) => {
         }
     });
     return packageJsonObject;
-};~
+};
 
 function getLineFeed(source: string) {
     const match = source.match(/\r?\n/);


### PR DESCRIPTION
Discussed in https://github.com/vasilevich/sync-yarnlock-into-packagejson/issues/8

I've been using [my own fork](https://github.com/ashleyw/sync-yarnlock-into-packagejson) with this change for a few months. I think tildes are a great strategy for managing NPM dependencies (upgrading caret [^] dependencies can be dangerous!), so it'd be good if this project supported them.