### PR TITLE
Make yarn workspace support work with nohoist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,8 @@ yarnconverter.toObject().then((yarnLockObj) => {
         const packageJson = JSON.parse(packageJsonText);
 
         if (packageJson.workspaces) {
-            packageJson.workspaces.forEach((packagePath: string) => {
+            const packagePaths = packageJson.workspaces.packages || packageJson.workspaces;
+            packagePaths.forEach((packagePath: string) => {
                 const packages = glob.sync(`${packagePath}${packagePath.endsWith('/') ? '' : '/'}`, { absolute: true });
                 packages.forEach(x => updatePackage(path.join(x, 'package.json')));
             });


### PR DESCRIPTION
When yarn added the [nohoist option](https://yarnpkg.com/blog/2018/02/15/nohoist/) to workspaces, it added a different way to configure them (`workspaces: {packages: ["packages/*"], nohoist: ["x","y"]}` instead of `workspaces: ["packages/*"]`).  The workspace support added in #10 didn't support using the new way with `nohoist`.  This PR makes it work either way.