### PR TITLE
Sync only versions of direct dependencies fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,6 @@ function updatePackage(jsonPath: string, rootDeps) {
 const dir = program.dir ? program.dir : process.cwd();
 const packageDir = program.dirPackageJson ? program.dirPackageJson : dir;
 
-const depsTree = JSON.parse(childProcess.execSync("yarn list --json --depth 1").toString()).data.trees;
+const depsTree = JSON.parse(childProcess.execSync("yarn list --json --depth 0").toString()).data.trees;
 
 updatePackage(path.resolve(packageDir, 'package.json'), depsTree);


### PR DESCRIPTION
Fixes a bug in implementation of https://github.com/vasilevich/sync-yarnlock-into-packagejson/pull/14 causing an issue when a different version of a package is referenced directly and as a first-level indirect dependency.

See the description of https://github.com/vasilevich/sync-yarnlock-into-packagejson/pull/14 for more details