### PR TITLE
Omit folders that do not contain a package.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ function getLineFeed(source: string) {
 // Only the root package.json file contains a workspaces field
 // But to simplify the code we don't seperate the logic
 function updatePackage(jsonPath: string, rootDeps) {
+    if (!fs.existsSync(jsonPath)) return;
     const packageJsonText = fs.readFileSync(jsonPath, 'utf8');
     const packageJson = JSON.parse(packageJsonText);
     const saveTo = path.resolve(path.dirname(jsonPath), program.save ? 'package.json' : 'package.json.yarn');


### PR DESCRIPTION
In our mono repository, we have folders that match the `workspaces` regex in the root package.json file, but do not contain their own package.json file themselves. This PR adds a check as to whether a package json in a given folder exists before trying to access it